### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This example was made with the following software:
 * Visual Studio Code version 1.32.3  
 * Visual Studio Code Extensions:
     * CMake (twxs.cmake) version 0.0.17
-    * CMake Tools (vector-of-bool.cmake-tools) version 1.1.3
+    * CMake Tools (ms-vscode.cmake-tools) version 1.2.3
     * C/C++ (ms-vscode.cpptools) version 0.22.1
 * PLCnext SDK 2019.0 LTS for AXC F 2152
 * PLCnext SDK 2019.3 beta bundle 1 for AXC F 2152
@@ -27,7 +27,7 @@ This example was made with the following software:
 
 Install the listed extension into Visual Studio Code
 
-* CMake Tools (vector-of-bool.cmake-tools)
+* CMake Tools (ms-vscode.cmake-tools)
 * CMake (twxs.cmake)
 * C/C++ (ms-vscode.cpptools)
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ mark_as_advanced(
 
 The jsoncpp library comes with support for a CMake config package that can easily be consumed from the install location. The library has just to be installed into a local directory. By including the installation directory into the `CMAKE_PREFIX_PATH` variable CMake can find this package. To learn more about CMake packages read the [CMake packages documentation](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#cmake-packages-7).
 
-The install location for this workspace is always in the build folder of the specific CMake Tools build kit. Take a look at the build kit file `./vscode/build-kits.cmake`. The `CMAKE_STAGING_PREFIX` variable is set to the `out` folder in the build directory.
+The install location for this workspace is always in the build folder of the specific CMake Tools build kit. Take a look at the build kit file `./vscode/cmake-kits.json`. The `CMAKE_STAGING_PREFIX` variable is set to the `out` folder in the build directory.
 
 ```json
 {


### PR DESCRIPTION
CMake Tools maintainer changed (7/12/19)
vector-of-bool has moved on to other things and Microsoft is now maintaining this extension.